### PR TITLE
Generate images with GitHub action.

### DIFF
--- a/.github/workflows/generate_images.yaml
+++ b/.github/workflows/generate_images.yaml
@@ -1,0 +1,34 @@
+name: Generate prebuilt images
+on: [push, pull_request]
+
+jobs:
+  buildroot:
+    name: Build
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        defconfig_name: [qemu_x86_defconfig, qemu_x86_64_defconfig, raspberrypi4_defconfig, raspberrypi4_64_defconfig, qemu_ppc64le_pseries_defconfig, qemu_mips32r2_malta_defconfig, qemu_mips64_malta_defconfig]
+        libc_name: [glibc, uclibc, musl]
+    env:
+      BUILDROOT_DIRECTORY_NAME: /home/runner/buildroot-${{ matrix.defconfig_name }}-${{ matrix.libc_name }}
+    permissions:
+      contents: write
+    steps:
+      - name: Retrieve CI scripts
+        uses: actions/checkout@v3
+      - name: Run build script
+        run: |
+          bash -x ${{ github.workspace }}/build-buildroot.sh ${{ matrix.defconfig_name }} ${{ matrix.libc_name }} /home/runner
+      - name: Archive image
+        run: |
+          tar -c ${{ env.BUILDROOT_DIRECTORY_NAME }} -f ${{ env.BUILDROOT_DIRECTORY_NAME }}.tar
+      - name: Compress image
+        run: |
+          zstd -T0 -19 --rm -v ${{ env.BUILDROOT_DIRECTORY_NAME }}.tar
+      - name: Deploy image to repository release
+        if: startsWith(github.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.BUILDROOT_DIRECTORY_NAME }}.tar.zst
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}

--- a/build-buildroot.sh
+++ b/build-buildroot.sh
@@ -23,7 +23,7 @@ OUTPUT_DIRECTORY="$3"
 
 # Create the build directory name
 BUILD_DIRECTORY_NAME="buildroot-${DEFCONFIG_NAME}-${LIBC_NAME}"
-BUILD_DIRECTORY_PATH=$(realpath "${OUTPUT_DIRECTORY}/${BUILD_DIRECTORY_NAME}")
+BUILD_DIRECTORY_PATH=$(realpath "${OUTPUT_DIRECTORY}")/"${BUILD_DIRECTORY_NAME}"
 
 PrintMessage "Removing previous build artifacts..."
 rm -rf $BUILD_DIRECTORY_PATH

--- a/build-buildroot.sh
+++ b/build-buildroot.sh
@@ -29,7 +29,7 @@ PrintMessage "Removing previous build artifacts..."
 rm -rf $BUILD_DIRECTORY_PATH
 
 PrintMessage "Downloading Buildroot sources..."
-git clone --depth=1 --branch=2021.02.5 https://git.busybox.net/buildroot $BUILD_DIRECTORY_PATH
+git clone --depth=1 --branch=2021.02.5 https://github.com/buildroot/buildroot $BUILD_DIRECTORY_PATH
 
 PrintMessage "Modifying the PPP package to use upstream PPP sources..."
 PPP_PACKAGE_PATH="${BUILD_DIRECTORY_PATH}/package/pppd"


### PR DESCRIPTION
Generate and deploy all Buildroot images used in the PPP CI directly on GitHub.
This improvement will allow to more easily add CI target architectures and also to update the Buildroot version when needed later.